### PR TITLE
Fix Issue #1853

### DIFF
--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
@@ -929,7 +929,9 @@ public class CalendarModule extends ExportedModule implements RegistryLifecycleL
   private ArrayList<String> calendarAllowedRemindersFromDBString(String dbString) {
     ArrayList<String> array = new ArrayList<>();
     for (String constant : dbString.split(",")) {
+      if(!constant.isEmpty() && constant.matches("-?\\d+")){
       array.add(reminderStringMatchingConstant(Integer.parseInt(constant)));
+      }
     }
     return array;
   }
@@ -1118,7 +1120,9 @@ public class CalendarModule extends ExportedModule implements RegistryLifecycleL
   private ArrayList<String> calendarAllowedAttendeeTypesFromDBString(String dbString) {
     ArrayList<String> array = new ArrayList<>();
     for (String constant : dbString.split(",")) {
+      if(!constant.isEmpty() && constant.matches("-?\\d+")){
       array.add(attendeeTypeStringMatchingConstant(Integer.parseInt(constant)));
+      }
     }
     return array;
   }


### PR DESCRIPTION

# Why

On android, Expo Calendar throws a fatal error if the device used has another app installed for calendar management such as the one mentioned in issue #1853, or in my case "Nine - Email & Calendar" if it is used to sync certain calendars (e.g outlook). 
The error thrown is: `Fatal Exception: java.lang.NumberFormatException: For input string: ""`

Steps to reproduce error: 
1. Install an app that uses Expo Calendar and retrieves the calendars on the device, for example by calling `ExpoCalendar.getCalendarsAsync()`
2. Verify calendars are fetched an app does not crash
3. Create an Outlook account
4. Install "Nine - Email & Calendar" App and sync the calendar with the new Outlook account
5. Open the app that uses Expo Calendar

Result: App will crash


# How

To avoid this fatal error  I added a check to make sure the string is a parsable integer.

# Test Plan

1. Install an app that uses Expo Calendar and retrieves the calendars on the device, for example by calling `ExpoCalendar.getCalendarsAsync()`
2. Verify calendars are fetched an app does not crash
3. Create an Outlook account
4. Install "Nine - Email & Calendar" App and sync the calendar with the new Outlook account
5. Open the app that uses Expo Calendar

Result: App will not crash this time

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).